### PR TITLE
fix: stabilize magnetometer calibration

### DIFF
--- a/__mocks__/react-native-vision-camera.js
+++ b/__mocks__/react-native-vision-camera.js
@@ -1,0 +1,10 @@
+const React = require('react');
+
+const Camera = React.forwardRef(() => null);
+Camera.getCameraPermissionStatus = async () => 'granted';
+Camera.requestCameraPermission = async () => 'granted';
+
+module.exports = {
+  Camera,
+  useCameraDevice: () => null,
+};

--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -6,6 +6,28 @@ import React from 'react';
 import ReactTestRenderer from 'react-test-renderer';
 import App from '../App';
 
+jest.mock('react-native-vision-camera');
+jest.mock('react-native-fs', () => ({
+  PicturesDirectoryPath: '/tmp',
+}));
+jest.mock('react-native-geolocation-service', () => ({
+  requestAuthorization: jest.fn(),
+  getCurrentPosition: jest.fn(),
+  watchPosition: jest.fn(),
+  clearWatch: jest.fn(),
+}));
+jest.mock('react-native-compass-heading', () => ({
+  start: jest.fn(),
+  stop: jest.fn(),
+}));
+jest.mock('react-native-sensors', () => ({
+  accelerometer: {
+    subscribe: jest.fn(() => ({unsubscribe: jest.fn()})),
+  },
+  setUpdateIntervalForType: jest.fn(),
+  SensorTypes: {accelerometer: 'accelerometer'},
+}));
+
 test('renders correctly', async () => {
   await ReactTestRenderer.act(() => {
     ReactTestRenderer.create(<App />);

--- a/useCalibratedMagnetometer.js
+++ b/useCalibratedMagnetometer.js
@@ -72,10 +72,6 @@ export const useCalibratedMagnetometer = () => {
   }, [finishCalibration]);
 
   useEffect(() => {
-
-    calibrate();
-    return () => {
-
     const accelSub = accelerometer.subscribe(({x, y, z}) => {
       const pitch = Math.atan2(-x, Math.sqrt(y * y + z * z)) * (180 / Math.PI);
       const roll = Math.atan2(y, z) * (180 / Math.PI);
@@ -95,6 +91,7 @@ export const useCalibratedMagnetometer = () => {
         isTiltedRef.current = !vertical;
       }
     });
+
     calibrate();
     return () => {
       accelSub.unsubscribe();
@@ -116,9 +113,6 @@ export const useCalibratedMagnetometer = () => {
       subscription.unsubscribe();
     };
   }, []);
-
-  const handleHeading = useCallback(
-    ({heading}) => {
 
   const handleHeading = useCallback(
     ({heading}) => {


### PR DESCRIPTION
## Summary
- fix magnetometer calibration hook with proper effects and heading handler
- add jest mocks for native modules to enable tests

## Testing
- `npm run lint`
- `npm test` *(fails: Jest did not exit one second after the test run has completed)*

------
https://chatgpt.com/codex/tasks/task_e_68aef80114b8832dac09f4c665e5c961